### PR TITLE
Removed minifaker dependency

### DIFF
--- a/dev/utils/index.ts
+++ b/dev/utils/index.ts
@@ -1,9 +1,8 @@
 import { ChartData, ChartDataset } from 'chart.js'
-import { number } from 'minifaker'
 
 export const generateRandomDataset = (labels: string[], index: number) => ({
     label: 'Dataset ' + index,
-    data: labels.map(() => number({ min: -100, max: 100 })),
+    data: labels.map(() => Math.random() * 200 - 100),
 })
 
 export const generateRandomChartData = (datasetsLength = 2): ChartData => {

--- a/package.json
+++ b/package.json
@@ -118,9 +118,6 @@
     "vitest": "^0.31.0",
     "vitest-canvas-mock": "^0.2.2"
   },
-  "dependencies": {
-    "minifaker": "^1.34.1"
-  },
   "keywords": [
     "solid",
     "solidjs",


### PR DESCRIPTION
Minifaker.js was used to create random data for testing, I thought it would be better to remove it now, as it's only used once and your package is published.  One less dependency to care about.