### PR TITLE
Added extraCanvasAttributes

### DIFF
--- a/src/chart.tsx
+++ b/src/chart.tsx
@@ -112,7 +112,8 @@ export default function DefaultChart(props: ChartProps) {
         <canvas
             ref={mergeRefs(props.ref, (el) => setCanvasRef(el))}
             height={merged.height}
-            width={merged.width}>
+            width={merged.width}
+            {...merged.extraCanvasProps}>
             {merged.fallback}
         </canvas>
     )

--- a/src/chart.tsx
+++ b/src/chart.tsx
@@ -113,7 +113,7 @@ export default function DefaultChart(props: ChartProps) {
             ref={mergeRefs(props.ref, (el) => setCanvasRef(el))}
             height={merged.height}
             width={merged.width}
-            {...merged.extraCanvasProps}>
+            {...merged.extraCanvasAttributes}>
             {merged.fallback}
         </canvas>
     )

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,7 @@ export interface ChartProps {
      */
     ref?: Ref<HTMLCanvasElement | null>
     /**
-     * Extra props to be forwarded directly to the canvas
+     * Extra attributes to be forwarded directly to the canvas
      *
      * For example for setting the `id`, `role`, or `aria-label`.
      *
@@ -61,5 +61,5 @@ export interface ChartProps {
      * which can be set directly.
      * @default {}
      */
-    extraCanvasProps?: Omit<JSX.CanvasHTMLAttributes<HTMLCanvasElement>, 'width' | 'height'>
+    extraCanvasAttributes?: Omit<JSX.CanvasHTMLAttributes<HTMLCanvasElement>, 'width' | 'height'>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type { Ref } from '@solid-primitives/refs'
 import type { ChartData, ChartOptions, Plugin, ChartTypeRegistry } from 'chart.js'
-import type { JSXElement } from 'solid-js'
+import type { JSXElement, JSX } from 'solid-js'
 
 /**
  * Chart props
@@ -52,4 +52,14 @@ export interface ChartProps {
      * @default null
      */
     ref?: Ref<HTMLCanvasElement | null>
+    /**
+     * Extra props to be forwarded directly to the canvas
+     *
+     * For example for setting the `id`, `role`, or `aria-label`.
+     *
+     * This can be used for any attribute except `width` and `height`,
+     * which can be set directly.
+     * @default {}
+     */
+    extraCanvasProps?: Omit<JSX.CanvasHTMLAttributes<HTMLCanvasElement>, 'width' | 'height'>
 }


### PR DESCRIPTION
fixes #17
Allowing users to specify any extra attributes they like to be passed directly to the underlying `canvas` element.
Adds new `extraCanvasAttributes` property to all chart components.